### PR TITLE
zooming while panned

### DIFF
--- a/appengine/js/editor.js
+++ b/appengine/js/editor.js
@@ -208,8 +208,9 @@ function showSvgModal() {
 	}
 
 	var panzoom = $('#zoom-canvas').panzoom({
-		maxScale: 5,
+		maxScale: 10,
 		minScale: 1,
+		contain: 'invert',
 		$zoomRange: $(".modal-header .zoom-range"),
 		$reset: $(".modal-header .zoom-reset")
 	}).panzoom("reset");


### PR DESCRIPTION
From #15:

> There's a strange behavior when zooming while panned. It doesn't appear to zoom within the current view. To see this:
> 1. pick an example with a large graph, say `Datalog` > `Two Cycles`.
> 2. zoom in and pan to the bottom left operator.
> 3. zoom out. The graph goes off screen!
> 
> Since we can reset the view, I will merge this now. But fixing this zoom-while-panned bug would be awesome!
