### PR TITLE
profile: reported times off from visualized bars?

### DIFF
--- a/appengine/js/fragmentvis.js
+++ b/appengine/js/fragmentvis.js
@@ -453,7 +453,7 @@ function drawLanes(element, fragmentId, queryId, numWorkers) {
                     }
                     content += ', ';
                 }
-                content += templates.duration({ duration: customTimeFormat(d.end - d.begin) });
+                content += templates.duration({ duration: customFullTimeFormat(d.end - d.begin) });
                 return content;
             });
         });


### PR DESCRIPTION
Q#2223
Fragment 0
Worker 36
around time = 1s 778ms 083763ns

![screen shot 2014-04-09 at 4 18 51 pm](https://cloud.githubusercontent.com/assets/526415/2662451/9773ea04-c03d-11e3-88f3-9956ca3c4c01.png)

The highlighted bar, `V0`, says it takes `3.82e+5ns`.

The bar to its left, `V5`, says it takes `1.21e+5ns`.

This difference is way bigger than a factor of 3. I wonder if maybe times are wrong?
