### PR TITLE
myria-web: report concise runtimes where appropriate

### DIFF
--- a/appengine/js/fragmentvis.js
+++ b/appengine/js/fragmentvis.js
@@ -568,7 +568,7 @@ function drawLanes(element, fragmentId, queryId, numWorkers, idNameMapping, leve
                     }
                     content += ', ';
                 }
-                content += templates.duration({ duration: customFullTimeFormat(d.endTime - d.startTime) });
+                content += templates.duration({ duration: customFullTimeFormat(d.endTime - d.startTime, false) });
                 return content;
             });
         });

--- a/appengine/js/networkvis.js
+++ b/appengine/js/networkvis.js
@@ -323,7 +323,7 @@ var updateSummary = function(element, summary) {
     var items = "";
     items += templates.defItem({key: "# Tuples", value: Intl.NumberFormat().format(summary.numTuples)});
     items += templates.defItem({key: "Local tuples sent", value: summary.localTuples});
-    items += templates.defItem({key: "Duration", value: customFullTimeFormat(summary.duration)});
+    items += templates.defItem({key: "Duration", value: customFullTimeFormat(summary.duration, false)});
     items += templates.defItem({key: "Tuples per second", value: (summary.numTuples / summary.duration * 1000000).toFixed(3)});
     var dl = templates.defList({items: items});
     $(element.node()).html(dl);

--- a/appengine/js/operatorvis.js
+++ b/appengine/js/operatorvis.js
@@ -87,8 +87,8 @@ var operatorVisualization = function (element, fragmentId, queryPlan, graph) {
             .attr("cy", 8)
             .attr("class", "rect-info")
             .popover(function(d) {
-                var body = templates.row({key: "Overall runtime", value: customFullTimeFormat(d.nanoTime)});
-                body += templates.row({key: "Time spent in this operator", value: customFullTimeFormat(d.timeWithoutChildren)});
+                var body = templates.row({key: "Overall runtime", value: customFullTimeFormat(d.nanoTime, false)});
+                body += templates.row({key: "Time spent in this operator", value: customFullTimeFormat(d.timeWithoutChildren, false)});
                 _.each(d.rawData, function(value, key){
                     if (key == 'operators') {
                         return;

--- a/appengine/js/queryvis.js
+++ b/appengine/js/queryvis.js
@@ -110,7 +110,10 @@ function debug(d) {
 }
 
 function customFullTimeFormat(d, detail) {
-    var str = "", ns, us, ms, s, m, h, x, done=false;
+    if (d === 0) {
+        return "0";
+    }
+    var str = "", ns, us, ms, s, m, h, x;
     if (detail === undefined) {
         detail = true;
     }
@@ -126,43 +129,34 @@ function customFullTimeFormat(d, detail) {
     x = divmod(x[0], 60);
     m = x[1];
     h = x[0];
+    // time_objs is an array of triples: an int constant, a unit string, and an
+    // optional function that stringifies the constant when the output string
+    // has already been prefixed by another nonzero unit.
+    var time_objs = [
+        [h, 'h', null],
+        [m, 'm', null],
+        [s, 's', null],
+        [ms, 'ms', d3.format("03d")],
+        [us, 'µs', d3.format("03d")],
+        [ns, 'ns', d3.format("03d")]
+    ];
 
-    if (h) {
-        str = h + " h ";
-    }
-    if (m) {
-        str += m + " m ";
-        if (!detail && h) {
+    function id(x) { return x; } // the identify function
+    var old_str = "";
+    for (var i = 0, f = id; i < time_objs.length; ++i) {
+        var to = time_objs[i];
+        if (to[0]) {
+            if (old_str) {
+                str += " ";
+                f = to[2] || f;
+            }
+            str += f(to[0]) + " " + to[1];
+        }
+        if (!detail && old_str) {
             return str;
         }
+        old_str = str;
     }
-    if (s) {
-        str += s + " s ";
-        if (!detail && m) {
-            return str;
-        }
-    }
-    if (ms) {
-        if (s) {
-            str += d3.format("03d")(ms) + " ms ";
-            if (!detail) {
-                return str;
-            }
-        } else {
-            str = ms + " ms ";
-        }
-    }
-    if (us) {
-        if (ms) {
-            str += d3.format("03d")(us) + " µs ";
-            if (!detail) {
-                return str;
-            }
-        } else {
-            str = us + " µs ";
-        }
-    }
-    str += d3.format("03d")(ns) + " ns ";
     return str;
 }
 


### PR DESCRIPTION
E.g., in infoboxes about operators, in the network view, etc.

The only place we need detailed times is in the gantt charts and x-axes.

Also refactor the code in `customFullTimeFormat` to be more modular/clear.
