### PR TITLE
editor: fall back to relational plan visualizer

### DIFF
--- a/appengine/js/editor.js
+++ b/appengine/js/editor.js
@@ -69,12 +69,12 @@ function optimizeplan() {
         g.render(d3.select('#myria_svg'));
       }
 
-      rerender();
-
       // rerender when opening tab because of different space available
       $('a[href="#queryplan"]').on('shown.bs.tab', rerender);
       $('#relational-plan').collapse('hide');
       $('#physical-plan').collapse('show');
+      rerender();
+
     } catch (err) {
       $('#myria_svg').empty();
       $('#optimized').empty();


### PR DESCRIPTION
We cannot yet visualize the physical plans that include Sequence or
DoWhile operators using the new hotness. For these queries, we can only
show the relational plan using the old coldness.

Catch errors visualizing physical plans in the general case, and when
they occur hide the physical plan and show the relational plan.

Vice versa -- when parsing a new query and hence visualizing a new plan,
if the visualizer succeeds then hide the relational plan and show the
physical plan.

fyi @stechu  @domoritz  
