### PR TITLE
deploy.sh: recreate parsetab.py

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,12 @@ elif [ "production" != "$cur_branch" ]
 then
 	echo "myria-web is not on the production branch; cannot deploy"
 else
+	# make sure that raco's parsetab.py is up to date
+	pushd submodules/raco ; ./scripts/myrial examples/uda.myl > /dev/null ; raco_exit_code=$? ; popd
+	if [[ $raco_exit_code != 0 ]] ; then
+		echo "could not re-create parsetab.py in raco submodule; cannot deploy"
+		exit
+	fi
 	git rev-parse HEAD > appengine/VERSION && \
 	git rev-parse --abbrev-ref HEAD > appengine/BRANCH && \
 	appcfg.py --oauth2 update appengine


### PR DESCRIPTION
@domoritz as discussed, this will recreate parsetab.py on deploy. requires virtual or other environments configured properly so that raco scripts can run.
