### PR TITLE
Profile subqueries

### DIFF
--- a/appengine/js/editor.js
+++ b/appengine/js/editor.js
@@ -86,16 +86,17 @@ function optimizeplan() {
       multiway_join: multiway_join_checked,
       push_sql: push_sql_checked
   });
-  request.success(function (queryPlan) {
+  request.success(function (queryStatus) {
     try {
+      var fragments = queryStatus.plan.fragments;
       var i = 0;
-      _.map(queryPlan.plan.fragments, function (frag) {
+      _.map(fragments, function (frag) {
         frag.fragmentIndex = i++;
         return frag;
       });
 
       var g = new Graph();
-      g.loadQueryPlan(queryPlan);
+      g.loadQueryPlan(queryStatus, fragments);
 
       function rerender() {
         $('#myria_svg').empty().height('auto');

--- a/appengine/js/networkvis.js
+++ b/appengine/js/networkvis.js
@@ -1,4 +1,4 @@
-var networkVisualization = function (element, fragments, queryPlan, linkAttr) {
+var networkVisualization = function (element, fragments, queryStatus, linkAttr) {
     $('.title-current').html(templates.titleNetworkVis({src: fragments[0], dst: fragments[1]}));
 
     $(element.node()).empty();
@@ -78,7 +78,8 @@ var networkVisualization = function (element, fragments, queryPlan, linkAttr) {
         var fragmentId = fragments[0];
         var url = templates.urls.sentData({
             myria: myriaConnection,
-            query: queryPlan.queryId,
+            query: queryStatus.queryId,
+            subquery: queryStatus.subqueryId,
             fragment: fragmentId
         });
 

--- a/appengine/js/operatorvis.js
+++ b/appengine/js/operatorvis.js
@@ -1,4 +1,4 @@
-var operatorVisualization = function (element, fragmentId, queryPlan, graph) {
+var operatorVisualization = function (element, fragmentId, graph) {
     $(element.node()).empty();
 
     var hierarchy = graph.nested["f"+fragmentId],
@@ -13,7 +13,7 @@ var operatorVisualization = function (element, fragmentId, queryPlan, graph) {
     }
     addLevels(hierarchy, 0);
 
-    var idNameMapping = nameMappingFromFragments(queryPlan.plan.fragments);
+    var idNameMapping = nameMappingFromFragments(graph.fragments);
 
     var margin = {top: 5, right: 5, bottom: 5, left: 5 },
         width = parseInt(element.style('width'), 10) - margin.left - margin.right,
@@ -31,7 +31,8 @@ var operatorVisualization = function (element, fragmentId, queryPlan, graph) {
 
     var url = templates.urls.contribution({
         myria: myriaConnection,
-        query: queryPlan.queryId,
+        query: graph.queryStatus.queryId,
+        subquery: graph.queryStatus.subqueryId,
         fragment: fragmentId
     });
 

--- a/appengine/js/querystats.js
+++ b/appengine/js/querystats.js
@@ -1,7 +1,8 @@
-var updateQueryStats = function(element) {
+var updateQueryStats = function(element, queryStatus) {
     var shuffleUrl = templates.urls.aggregatedSentData({
             myria: myriaConnection,
-            query: queryPlan.queryId
+            query: queryStatus.queryId,
+            subquery: queryStatus.subqueryId
         });
 
     d3.csv(shuffleUrl, function(d) {
@@ -17,7 +18,7 @@ var updateQueryStats = function(element) {
                 return a + b.numTuples;
             }, 0);
             var items = "";
-            items += templates.defItem({key: "Running time:", value: customFullTimeFormat(queryPlan.elapsedNanos, false)});
+            items += templates.defItem({key: "Running time:", value: customFullTimeFormat(queryStatus.elapsedNanos, false)});
             items += templates.defItem({key: "# shuffled tuples:", value: Intl.NumberFormat().format(totalTuple)});
             var dl = templates.defList({items: items});
             $(".query-stats").append(dl);

--- a/appengine/js/queryvis.js
+++ b/appengine/js/queryvis.js
@@ -2,12 +2,12 @@
 var templates = {
     //*/
     urls: {
-        sentData: _.template("<%- myria %>/logs/sent?queryId=<%- query %>&fragmentId=<%- fragment %>"),
-        aggregatedSentData: _.template("<%- myria %>/logs/aggregated_sent?queryId=<%- query %>"),
-        profiling: _.template("<%- myria %>/logs/profiling?queryId=<%- query %>&fragmentId=<%- fragment %>&start=<%- start %>&end=<%- end %>&onlyRootOp=<%- onlyRootOp %>&minLength=<%- minLength %>"),
-        range: _.template("<%- myria %>/logs/range?queryId=<%- query %>&fragmentId=<%- fragment %>"),
-        contribution: _.template("<%- myria %>/logs/contribution?queryId=<%- query %>&fragmentId=<%- fragment %>"),
-        histogram: _.template("<%- myria %>/logs/histogram?queryId=<%- query %>&fragmentId=<%- fragment %>&start=<%- start %>&end=<%- end %>&step=<%- step %>&onlyRootOp=<%- onlyRootOp %>")
+        sentData: _.template("<%- myria %>/logs/sent?queryId=<%- query %>&subqueryId=<%- subquery %>&fragmentId=<%- fragment %>"),
+        aggregatedSentData: _.template("<%- myria %>/logs/aggregated_sent?queryId=<%- query %>&subqueryId=<%- subquery %>"),
+        profiling: _.template("<%- myria %>/logs/profiling?queryId=<%- query %>&subqueryId=<%- subquery %>&fragmentId=<%- fragment %>&start=<%- start %>&end=<%- end %>&onlyRootOp=<%- onlyRootOp %>&minLength=<%- minLength %>"),
+        range: _.template("<%- myria %>/logs/range?queryId=<%- query %>&subqueryId=<%- subquery %>&fragmentId=<%- fragment %>"),
+        contribution: _.template("<%- myria %>/logs/contribution?queryId=<%- query %>&subqueryId=<%- subquery %>&fragmentId=<%- fragment %>"),
+        histogram: _.template("<%- myria %>/logs/histogram?queryId=<%- query %>&subqueryId=<%- subquery %>&fragmentId=<%- fragment %>&start=<%- start %>&end=<%- end %>&step=<%- step %>&onlyRootOp=<%- onlyRootOp %>")
     },
     /*/
     urls: {

--- a/appengine/myria_web_main.py
+++ b/appengine/myria_web_main.py
@@ -328,16 +328,22 @@ class Profile(MyriaPage):
     def get(self):
         conn = self.app.connection
         query_id = self.request.get("queryId")
-        query_plan = {}
+        subquery_id = self.request.get("subqueryId", 0)
+        query_status = {}
+        subquery_fragments = None
         if query_id != '':
             try:
-                query_plan = conn.get_query_status(query_id)
+                query_status = conn.get_query_status(query_id)
+                query_status["subqueryId"] = subquery_id
+                subquery_fragments = conn.get_query_plan(query_id, subquery_id)
             except myria.MyriaError:
                 pass
 
         template_vars = self.base_template_vars()
-        template_vars['queryPlan'] = json.dumps(query_plan)
+        template_vars['queryStatus'] = json.dumps(query_status)
+        template_vars['fragments'] = json.dumps(subquery_fragments)
         template_vars['queryId'] = query_id
+        template_vars['subqueryId'] = subquery_id
 
         # Actually render the page: HTML content
         self.response.headers['Content-Type'] = 'text/html'

--- a/appengine/templates/visualization.html
+++ b/appengine/templates/visualization.html
@@ -10,7 +10,7 @@
 
 {% block content %}
     <div class="page-header">
-  		<h1>Query {{ queryId }} <small>visualization of physical query execution</small></h1>
+		<h1>Query {{ queryId }}.{{ subqueryId }} <small>visualization of physical query execution</small></h1>
 	</div>
 
 	<p class="lead">
@@ -65,16 +65,13 @@
 	<script src="js/colorlegend.js" type="text/javascript" charset="utf-8"></script>
 	<script src="js/viz.js" type="text/javascript" charset="utf-8"></script>
 
-	<script type="text/javascript">
-		{% autoescape false %}
-			var queryPlan = {{ queryPlan }};
-		{% endautoescape %}
-	</script>
 	<script type="text/javascript" src="js/queryvis.js" charset="utf-8"></script>
 	<script async defer>
 		d3.select('.query-plan').each(function() {
-		    element = d3.select(this);
-		    theGraph = queryGraphInteractive(element, queryPlan);
+			var element = d3.select(this);
+			var queryStatus = {{ queryStatus | safe}};
+			var fragments = {{ fragments | safe }};
+			theGraph = queryGraphInteractive(element, queryStatus, fragments);
 		});
 
 		$(function() {


### PR DESCRIPTION
Lots of changes that let the user profile multiple subqueries of an executed query. Requires uwescience/myria#683.

Right now, the only way to access subqueries other than 0 is to put `&subqueryId=X` in the URL.

Tested on a 2-node postgres deployment on my local machine.