### PR TITLE
graph.js: fix #250

### DIFF
--- a/appengine/js/graph.js
+++ b/appengine/js/graph.js
@@ -748,7 +748,7 @@ function Graph () {
                 .attr("stroke", function(d) { return d.stroke; })
                 .attr("marker-end", function(d) { return templates.markerUrl({ name: d.id });})
                 .attr("stroke-width", function(d) {
-                    var x = self.linkAttr[self.linkOrigins[d.id]];;
+                    var x = self.linkAttr[self.linkOrigins[d.id]];
                     if (x !== undefined) {
                         return self.costs(x.numTuples);
                     }
@@ -771,13 +771,11 @@ function Graph () {
                     .tooltip(function(d) {
                         var k = self.linkOrigins[d.id];
                         // only show tooltip for links between fragments
-                        if (k !== undefined) {
-                            var x = self.linkAttr[k].numTuples;
-                            if (x === undefined)
-                                x = 0;
-                            return Intl.NumberFormat().format(x) + " tuples";
-                        }
-                        return "";
+												if (k === undefined) return "";
+												var x;
+												try {x = self.linkAttr[k].numTuples || 0;}
+												catch (_) {x = 0;}
+												return Intl.NumberFormat().format(x) + " tuples";
                     });
             }
 

--- a/appengine/js/graph.js
+++ b/appengine/js/graph.js
@@ -771,11 +771,11 @@ function Graph () {
                     .tooltip(function(d) {
                         var k = self.linkOrigins[d.id];
                         // only show tooltip for links between fragments
-												if (k === undefined) return "";
-												var x;
-												try {x = self.linkAttr[k].numTuples || 0;}
-												catch (_) {x = 0;}
-												return Intl.NumberFormat().format(x) + " tuples";
+                        if (k === undefined) return "";
+                        var x;
+                        try {x = self.linkAttr[k].numTuples || 0;}
+                        catch (_) {x = 0;}
+                        return Intl.NumberFormat().format(x) + " tuples";
                     });
             }
 


### PR DESCRIPTION
When I refactored the viz code to handle subqueries and move other
stuff around, I broke the existing code that handled edges with
0 tuples sense (that therefore do not appear in the received
aggregated sent statistics). Fix this bug.