### PR TITLE
Fix travis config by removing appengine from requirements-dev.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ install:
   - curl -O https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.17.zip && unzip -q google_appengine_1.9.17.zip
   - pip install -r requirements-dev.txt
 script: nosetests -w appengine --with-gae --exclude-dir={myria,raco,ply,networkx,sqlalchemy} --gae-lib-root=google_appengine
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ install:
   - curl -O https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.17.zip && unzip -q google_appengine_1.9.17.zip
   - pip install -r requirements-dev.txt
 script: nosetests -w appengine --with-gae --exclude-dir={myria,raco,ply,networkx,sqlalchemy} --gae-lib-root=google_appengine
-sudo: false

--- a/README.md
+++ b/README.md
@@ -75,17 +75,19 @@ Install the developer dependencies.
 pip install -r requirements-dev.txt
 ```
 
-Download a local copy of Google App Engine
+Download a local copy of [Google App Engine](https://cloud.google.com/appengine/downloads)
 
 ```sh
-curl -O http://googleappengine.googlecode.com/files/google_appengine_1.8.1.zip
-unzip -q google_appengine_1.8.1.zip
+curl -O https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.17.zip
+unzip -q google_appengine_1.9.17.zip
 ```
 
 Run
 
 ```
-nosetests -w appengine --with-gae --exclude-dir={myria,raco,ply,networkx} --without-sandbox --gae-lib-root=google_appengine
+nosetests -w appengine --with-gae \
+  --exclude-dir={myria,raco,ply,networkx,sqlalchemy} \
+  --gae-lib-root=google_appengine
 ```
 
 # Issues

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-appengine
 httmock
 nosegae
 nose-exclude


### PR DESCRIPTION
I cloned the repo, initialized the submodules, created and activated a virtualenv, pip installed requirements-dev.txt and then ran the tests using different sdks.

1. Test 1, using the instructions under [Run the tests](https://github.com/Trii/myria-web#run-the-tests) in the readme.

```
(jj)Josh@kapbook:myria-web$ ls
LICENSE				customize-bootstrap		google_appengine_1.9.17.zip
README.md			deploy.sh			requirements-dev.txt
appengine			google_appengine		submodules
(jj)Josh@kapbook:myria-web$ nosetests -w appengine --with-gae --exclude-dir={myria,raco,ply,networkx,sqlalchemy} --gae-lib-root=google_appengine

......................
----------------------------------------------------------------------
Ran 22 tests in 2.041s

OK
(jj)Josh@kapbook:myria-web$
```

2. Test 2, using the new google cloud sdk's provided appengine installed at `/Users/Josh/Developer/google-cloud-sdk/platform/google_appengine`
```
(jj)Josh@kapbook:myria-web$ ls /Users/Josh/Developer/google-cloud-sdk/platform/google_appengine
BUGS			_python_runtime.py	dev_appserver.py	gofmt			php_cli.py
LICENSE			api_server.py		dev_appserver.pyc	google			remote_api_shell.py
README			appcfg.py		download_appstats.py	google_sql.py		run_tests.py
RELEASE_NOTES		backends_conversion.py	endpointscfg.py		goroot			tools
RELEASE_NOTES.go_sdk	bulkload_client.py	gen_protorpc.py		lib			wrapper_util.py
VERSION			bulkloader.py		goapp			new_project_template	wrapper_util.pyc
_php_runtime.py		demos			godoc			php
(jj)Josh@kapbook:myria-web$ nosetests -w appengine --with-gae --exclude-dir={myria,raco,ply,networkx,sqlalchemy} --gae-lib-root=/Users/Josh/Developer/google-cloud-sdk/platform/google_appengine
......................
----------------------------------------------------------------------
Ran 22 tests in 2.055s

OK
```

Both completed successfully. I was also able to run the app using:

```
(jj)Josh@kapbook:myria-web$ ./google_appengine/dev_appserver.py appengine
INFO     2015-02-16 21:58:41,467 sdk_update_checker.py:229] Checking for updates to the SDK.
INFO     2015-02-16 21:58:41,579 sdk_update_checker.py:273] This SDK release is newer than the advertised release.
INFO     2015-02-16 21:58:41,587 api_server.py:172] Starting API server at: http://localhost:65288
INFO     2015-02-16 21:58:41,592 dispatcher.py:186] Starting module "default" running at: http://localhost:8080
INFO     2015-02-16 21:58:41,594 admin_server.py:118] Starting admin server at: http://localhost:8000
```

This is what I get when I hit the URL so I am assuming it works

![image](https://cloud.githubusercontent.com/assets/638073/6219873/22eb1674-b5fd-11e4-9745-273f497cb531.png)


Now we will see if Travis-CI marks this PR as OK! :8ball: 