### PR TITLE
Sparql backend

### DIFF
--- a/appengine/js/editor.js
+++ b/appengine/js/editor.js
@@ -31,6 +31,7 @@ var editorLanguage = 'myrial',
   backendProcess = 'myria',
   myriaends = ['myria', 'myriamultijoin'],
   grappaends = ['grappa', 'clang'],
+  noends = ['sparql'],
   editorState = {};
 
 function handleerrors(request, display) {
@@ -99,7 +100,7 @@ function optimizeplan() {
   });
 
   request.success(function (queryStatus) {
-    if (_.contains(grappaends, backendProcess)) {
+    if (_.contains(grappaends+noends, backendProcess)) {
       function clangrerender() {
         $('#svg').empty();
         var result = Viz(queryStatus.dot, "svg");
@@ -420,7 +421,7 @@ function changeBackend() {
 }
 
 function setBackend(backend) {
-  var backends = [ 'myria', 'grappa', 'clang', 'myriamultijoin'];
+  var backends = [ 'myria', 'grappa', 'clang', 'myriamultijoin', 'sparql'];
     if (!_.contains(backends, backend)) {
 	console.log('Backend not supported: ' + backend);
 	return;

--- a/appengine/myria_web_main.py
+++ b/appengine/myria_web_main.py
@@ -9,6 +9,7 @@ import jinja2
 
 from clang_backend import ClangBackend
 from grappa_backend import GrappaBackend
+from sparql_backend import SPARQLBackend
 from myria_backend import MyriaBackend, MyriaMultiJoinBackend
 import requests
 import webapp2
@@ -559,7 +560,8 @@ class Application(webapp2.WSGIApplication):
                          "myria": MyriaBackend(self.myriahostname,
                                                self.myriaport, ssl),
                          "myriamultijoin": MyriaMultiJoinBackend(
-                             self.myriahostname, self.myriaport, ssl)}
+                             self.myriahostname, self.myriaport, ssl),
+                         "sparql": SPARQLBackend(None, None, None)}
 
         # Quiet logging for production
         logging.getLogger().setLevel(logging.WARN)

--- a/appengine/sparql_backend.py
+++ b/appengine/sparql_backend.py
@@ -1,0 +1,48 @@
+from backend import Backend
+from sparql_catalog import SPARQLCatalog
+from raco.viz import operator_to_dot
+from raco.language.sparql import SPARQLAlgebra
+
+
+class SPARQLBackend(Backend):
+    def __init__(self, hostname, port, ssl):
+        pass
+
+    def catalog(self):
+        return SPARQLCatalog()
+
+    def algebra(self):
+        return SPARQLAlgebra()
+
+    def connection(self):
+        # want to remove this in #278
+        return None
+
+    def compile_query(self, query, logical_plan, physical_plan, language=None):
+        return {'rawQuery': str(query), 'logicalRa': str(logical_plan),
+                'plan': compile(physical_plan),
+                'dot': operator_to_dot(physical_plan)}
+
+    def execute_query(self, query, logical_plan, physical_plan, language=None,
+                      profile=False):
+        start_index = logical_plan.find("Store(") + 6
+        end_index = logical_plan.find(")", start_index)
+        relkey = logical_plan[start_index:end_index].replace(":", "_")
+        compiled = {'plan': compile(physical_plan), 'backend': "sparql",
+                'relkey': relkey, 'rawQuery': str(query)}
+        return {'query_status': compiled, 'query_url': ""}
+
+    def get_query_status(self, query_id):
+        return "(TODO status here)"
+
+    def connection_string(self):
+        return "local (SPARQL code only)"
+
+    def connection_url(self, uri_scheme):
+        return ""
+
+    def backend_url(self):
+        return ""
+
+    def queries(self, limit, max_id, min_id, q):
+        return "(TODO empty json?)"

--- a/appengine/sparql_backend.py
+++ b/appengine/sparql_backend.py
@@ -2,6 +2,7 @@ from backend import Backend
 from sparql_catalog import SPARQLCatalog
 from raco.viz import operator_to_dot
 from raco.language.sparql import SPARQLAlgebra
+from raco.compile import compile
 
 
 class SPARQLBackend(Backend):

--- a/appengine/sparql_catalog.py
+++ b/appengine/sparql_catalog.py
@@ -1,4 +1,5 @@
 from raco.catalog import Catalog
+from raco import scheme
 
 
 class SPARQLCatalog(Catalog):
@@ -9,7 +10,12 @@ class SPARQLCatalog(Catalog):
         return -1
 
     def get_scheme(self, rel_key):
-        return "(TODO scheme)"
+        # FIXME: hardcoding sp2bench
+        col_names = ['subject', 'object', 'predicate']
+        col_types = ['STRING_TYPE', 'STRING_TYPE', 'STRING_TYPE']
+        schema = {'columnNames': col_names, 'columnTypes': col_types}
+
+        return scheme.Scheme(zip(schema['columnNames'], schema['columnTypes']))
 
     def get_num_servers(self):
         return 1

--- a/appengine/sparql_catalog.py
+++ b/appengine/sparql_catalog.py
@@ -1,0 +1,17 @@
+from raco.catalog import Catalog
+
+
+class SPARQLCatalog(Catalog):
+    def __init__(self):
+        pass
+
+    def num_tuples(self, rel_key):
+        return -1
+
+    def get_scheme(self, rel_key):
+        return "(TODO scheme)"
+
+    def get_num_servers(self):
+        return 1
+
+

--- a/appengine/templates/editor.html
+++ b/appengine/templates/editor.html
@@ -55,6 +55,7 @@
                             <option value="myriamultijoin"> Myria Multiway Join </option>
 			                <option value="clang"> C </option>
 			                <option value="grappa"> Radish </option>
+			                <option value="sparql"> SPARQL </option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Support for sparql backend.

Non-fundamental limitations:
- harcoded catalog of sp2bench
- only editor view works

To view the generated sparql code look at the "plan" attribute of the json returned by clicking `JSON` button